### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = ""

--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ npm i
 npm run dev
 ```
 This will open a browser window and launch the game. You can now edit any of your files in <code>src/</code> or <code>resources/</code> and the game will automatically get rebuilt and the browser page will refresh. Pretty cool! You can debug and set break points in the Typescript source using the Developer Tab window in Chrome.
+
+[![Run on Repl.it](https://repl.it/badge/github/Little-Nomster/the-gems-game)](https://repl.it/github/Little-Nomster/the-gems-game)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@LittleNomster/the-gems-game).